### PR TITLE
mini-fix-1

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -316,13 +316,6 @@
         },
         {
             "MatchRegexString": ".*Menu$",
-            "Statement": {
-                "Equals": true,
-                "If": "Wallet Visibility",
-                "True": {
-                    "TargetCss": "config/WalletVisibility.css"
-                }
-            },
             "TargetCss": "Steam.css"
         },
         {
@@ -376,6 +369,17 @@
         {
             "MatchRegexString": "OverlayBrowser_Browser",
             "TargetCss": "overlay/Browser.css"
+        },
+        {
+            "MatchRegexString": "^Account.",
+            "Statement": {
+                "If": "Wallet Visibility",
+                "Equals": true,
+                "True": {
+                    "TargetCss": "config/WalletVisibility.css"
+                },
+                "False": {}
+            }
         }
     ],
     "Steam-WebKit": "webkit/webkit.css",

--- a/webkit/webkit.css
+++ b/webkit/webkit.css
@@ -16,7 +16,7 @@
     --border4: 0px; /* default 40px */
     --border5: 0px; /* default 50px */
     --border8: 0px; /* default 80px */
-    --border50: 50%; /* default 50% */
+    --border50: 0px; /* default 50% */
 }
 
 /* Scrollbar */


### PR DESCRIPTION
1. Fixed rounded avatar on activity page (#6)
2. Fixed wallet injection regex, now it won't be injected in every "**.^Menu$**", it will only inject on "**^Account.**" tab and header.

Suggested QOL: allow user to choose between rounded and box avatar for some pages and friends tab _(well maybe in the next update)_