### PR TITLE
Added Option to Hide "What's New"

### DIFF
--- a/config/WhatsNewVisibility.css
+++ b/config/WhatsNewVisibility.css
@@ -1,0 +1,3 @@
+._17uEBe5Ri8TMsnfELvs8-N {
+    display: none !important
+}

--- a/skin.json
+++ b/skin.json
@@ -17,6 +17,12 @@
             "ToolTip": "Hide URL bar when browsing inside steam",
             "Type": "CheckBox",
             "Value": false
+        },
+        {
+            "Name": "What's New Visibility",
+            "ToolTip": "Hide 'Whats New' on library page",
+            "Type": "CheckBox",
+            "Value": false
         }
     ],
     "GlobalsColors": [
@@ -307,6 +313,14 @@
                     "If": "URL Visibility",
                     "True": {
                         "TargetCss": "config/URLBarVisibility.css"
+                    }
+                },
+                {
+                    "Equals": true,
+                    "False": {},
+                    "If": "What's New Visibility",
+                    "True": {
+                        "TargetCss": "config/WhatsNewVisibility.css"
                     }
                 }
             ],


### PR DESCRIPTION
"What's New" tab on library now can be hidden via config