### PR TITLE
Fix for "Friend Search bar" and theming

### DIFF
--- a/Steam.css
+++ b/Steam.css
@@ -690,3 +690,13 @@ EG: "Play next" category names & "Sort by" dropdown */
 .settings_item.selected {
     background: var(--color-light) !important;
 }
+
+/* 'Add non-steam game' pop-up */
+
+._3m0MnUo45wjLOfNLpZ-3KH {
+    background-color: var(--color-dark) !important;
+}
+
+._1e6tjguQEHdYIehM9aRmO5 {
+    background-color: var(--color-darker) !important;
+}

--- a/skin.json
+++ b/skin.json
@@ -332,7 +332,8 @@
         },
         {
             "MatchRegexString": "friendsui-container",
-            "TargetCss": "steam/friends/FriendsList.css"
+            "TargetCss": "steam/friends/FriendsList.css",
+            "TargetJs": "steam/friends/FriendsList.js"
         },
         {
             "MatchRegexString": "ModalDialogPopup",

--- a/steam/friends/FriendsList.css
+++ b/steam/friends/FriendsList.css
@@ -90,6 +90,7 @@ img._338kJp62vHY5iDbsraaiKD {
 
 .tabLabel {
     width: 0px !important;
+    display: none !important;
 }
 
 .friendTab.socialListTab.activeTab {
@@ -107,10 +108,18 @@ img._338kJp62vHY5iDbsraaiKD {
     background: var(--color-light) !important;
 }
 
-.tabSearchTransitionGroup::after {
+/* .tabSearchTransitionGroup::after {
     position: absolute !important;
     padding-left: 5px !important;
     content: "Search for a friend...";
+    text-transform: none !important;
+    font-weight: 400 !important;
+    color: #666 !important;
+} */
+
+.searchPlaceholder {
+    position: absolute !important;
+    padding: 2px 0 0 10px !important;
     text-transform: none !important;
     font-weight: 400 !important;
     color: #666 !important;
@@ -118,4 +127,8 @@ img._338kJp62vHY5iDbsraaiKD {
 
 .chatRoomListContainer {
     background: var(--color-dark) !important;
+}
+
+.inputContainer.no-drag > input, .inputContainer.no-drag > input:focus {
+    background-color: var(--color-light)
 }

--- a/steam/friends/FriendsList.js
+++ b/steam/friends/FriendsList.js
@@ -1,0 +1,9 @@
+// Text content
+let searchText = "Search for a friend...";
+
+//Create a mutation that edit the search bar
+const obs = new MutationObserver((mutation) => {
+    if(!document.querySelector(".tabSearchTransitionGroup").hasChildNodes()) {
+        document.querySelector(".tabSearchTransitionGroup").innerHTML = `<div class='searchPlaceholder'>${searchText}</div>`;
+    }
+}).observe(document.body, { childList:true, subtree:true });


### PR DESCRIPTION
- Fixed "floating" text when using friends search bar (#14)
- Fixed friends search bar theming colors (#14)
- Fixed "Add non-steam" theming colors (#15)

_note_: If the _MutationObserver_ for friends tab starts acting like an idiot and take too much memory, please revert the updates, thanks.