### PR TITLE
Screenshot fix

### DIFF
--- a/Steam.css
+++ b/Steam.css
@@ -393,6 +393,10 @@ img._24_AuLm54JVe1Zc0AApCDR._3d_bT685lnWotXxgzKW6am.yDr03475kalWBTwAE-Rnw {
     padding: 6px;
 }
 
+.PP7LM0Ow1K5qkR8WElLpt._2yAm5LY_eu-Vg_52l0HFlM {
+    background-color: var(--darkergrey) !important;
+}
+
 ._2y2tUbsMx8OIwkimGSyHmb._3pofGqV0buiKAfMPEs3_82.Eq8Px4ixn5sAFSR6_9wWQ {
     border-radius: 6px;
 }


### PR DESCRIPTION
This PR fixes context menus being transparent in the screenshot window. 

<img width="1536" height="863" alt="before" src="https://github.com/user-attachments/assets/f85dda1a-dda6-40bc-95f3-90b55ee77d32" />
<img width="1536" height="863" alt="after" src="https://github.com/user-attachments/assets/76d64dce-69fc-4284-b5f7-63c25791a6d1" />




 